### PR TITLE
Fix for when ganache is normally used in project

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ https://github.com/marketplace/azure-pipelines
 
 - script: |
     npx truffle compile
-    npx truffle test
+    npx truffle test --network test
   displayName: 'truffle compile & test'
 ```
 


### PR DESCRIPTION
Ganache uses port 7454 so line 85 fails on Azure.
Selecting the default 'test' network that truffle provides creates a test network that is tore down after the tests.